### PR TITLE
Fix to avoid border color changing while empty

### DIFF
--- a/GRTextField/Classes/GRTextField.m
+++ b/GRTextField/Classes/GRTextField.m
@@ -218,7 +218,9 @@ NSString *const selectionRangeKey = @"selectionRange";
     if ([self.extension respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
         [self.extension textFieldDidBeginEditing:textField];
     }
-    [self setColorsOfField];
+    if (![NSString isNullOrEmpty:textField.text]) {
+        [self setColorsOfField];
+    }
 }
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField {

--- a/GRTextField/Classes/GRTextField.m
+++ b/GRTextField/Classes/GRTextField.m
@@ -26,6 +26,7 @@ NSString *const selectionRangeKey = @"selectionRange";
 -(void)awakeFromNib {
     [super awakeFromNib];
     [super setDelegate:self];
+    self.isValid = YES;
     [self initialization];
     [self layoutSubviews];
 }
@@ -49,7 +50,6 @@ NSString *const selectionRangeKey = @"selectionRange";
 }
 
 -(void)initialization {
-    self.isValid = YES;
     [self addBottomLine];
     if (self.hasBorder) {
         self.borderStyle = UITextBorderStyleNone;
@@ -60,15 +60,16 @@ NSString *const selectionRangeKey = @"selectionRange";
     }
 
     if (self.errorLabel) {
-        BOOL isEmpty = [NSString isNullOrEmpty:self.hintText];
+        BOOL isEmpty = [NSString GRIsNullOrEmpty:self.hintText];
+        if (self.isValid) {
+            self.errorLabel.text = self.hintText;
+            self.errorLabel.numberOfLines = 0;
+            self.errorLabel.lineBreakMode = NSLineBreakByWordWrapping;
 
-        self.errorLabel.text = self.hintText;
-        self.errorLabel.numberOfLines = 0;
-        self.errorLabel.lineBreakMode = NSLineBreakByWordWrapping;
-
-        [self.errorLabel setHidden:isEmpty];
-        if (isEmpty) {
-            self.errorLabel.textColor = self.errorBorderColor;
+            [self.errorLabel setHidden:isEmpty];
+            if (isEmpty) {
+                self.errorLabel.textColor = self.errorBorderColor;
+            }
         }
     }
 }
@@ -110,14 +111,14 @@ NSString *const selectionRangeKey = @"selectionRange";
 
     [self setColorsOfField];
 
-    BOOL isValidAndEmpty = _isValid && [NSString isNullOrEmpty:self.hintText];
+    BOOL isValidAndEmpty = _isValid && [NSString GRIsNullOrEmpty:self.hintText];
 
     [self.errorLabel setHidden:isValidAndEmpty];
 }
 
 -(void)setMaskPattern:(NSString *)maskPattern {
     _maskPattern = maskPattern;
-    if (![NSString isNullOrEmpty:maskPattern]) {
+    if (![NSString GRIsNullOrEmpty:maskPattern]) {
         self.keyboardType = UIKeyboardTypeNumberPad;
     }
 }
@@ -218,7 +219,7 @@ NSString *const selectionRangeKey = @"selectionRange";
     if ([self.extension respondsToSelector:@selector(textFieldDidBeginEditing:)]) {
         [self.extension textFieldDidBeginEditing:textField];
     }
-    if (![NSString isNullOrEmpty:textField.text]) {
+    if (![NSString GRIsNullOrEmpty:textField.text]) {
         [self setColorsOfField];
     }
 }
@@ -234,7 +235,7 @@ NSString *const selectionRangeKey = @"selectionRange";
     if ([self.extension respondsToSelector:@selector(textFieldDidEndEditing:)]) {
         [self.extension textFieldDidEndEditing:textField];
     }
-    [self setColorsOfField];
+    [self setError:[NSString GRIsNullOrEmpty:textField.text]];
 }
 
 -(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
@@ -254,7 +255,7 @@ NSString *const selectionRangeKey = @"selectionRange";
         textField.text = text;
     }
 
-    if(![NSString isNullOrEmpty:textField.text] && (self.errorLabel && !self.errorLabel.isHidden)) {
+    if(![NSString GRIsNullOrEmpty:textField.text] && (self.errorLabel && !self.errorLabel.isHidden)) {
         [self setError:NO];
     }
 
@@ -322,7 +323,7 @@ NSString *const selectionRangeKey = @"selectionRange";
 }
 
 - (void)setErrorWithMessage:(NSString *)message {
-    self.isValid = [NSString isNullOrEmpty:message];
+    self.isValid = [NSString GRIsNullOrEmpty:message];
     if (!self.isValid) {
         self.errorLabel.text = message;
     } else {

--- a/GRTextField/Extensions/NSString+GRTextField.h
+++ b/GRTextField/Extensions/NSString+GRTextField.h
@@ -23,7 +23,7 @@
  @param string The string that will be checked
  @return A boolean value indicating wether the string is null or empty
  */
-+(BOOL)isNullOrEmpty:(NSString*)string;
++(BOOL)GRIsNullOrEmpty:(NSString*)string;
 
 /**
  Transforms the string (numeric values) to match the pattern provided

--- a/GRTextField/Extensions/NSString+GRTextField.m
+++ b/GRTextField/Extensions/NSString+GRTextField.m
@@ -30,7 +30,7 @@
     return self;
 }
 
-+ (BOOL)isNullOrEmpty:(NSString *)string {
++ (BOOL)GRIsNullOrEmpty:(NSString *)string {
     if (string == nil || ![string isKindOfClass:[NSString class]] || [string isEqualToString:@""] || [string isEqualToString:@"null"]) {
         return YES;
     }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines
--
- [X] Use the following format: `* [owner/repo](link)`
- [X] Link additions should be added to the bottom of the relevant category.
- [X] New categories or improvements to the existing categorization are welcome.
- [X] Search previous suggestions before making a new one, as yours may be a duplicate.

## Fixes 
- TextField was changing the border color even if the user didn't type
  a text;

## Changes made/purposed on this pull request
-

Thanks for contributing!
